### PR TITLE
fixes #1 running specs leaks a ruby process

### DIFF
--- a/spec/futurist/process_completion_monitor_spec.rb
+++ b/spec/futurist/process_completion_monitor_spec.rb
@@ -16,7 +16,7 @@ describe Futurist::ProcessCompletionMonitor do
   it "is not complete when its process is still executing" do
     long_running_work = double(:work)
     process_id = fork do
-      sleep
+      sleep 5
       long_running_work
     end
 


### PR DESCRIPTION
- Prevent the forked process in the ProcessCompletionMonitor's "not
  complete" spec from sleeping indefinitely.
