### PR TITLE
Add additional ruby versions to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
 rvm:
+  - 2.2.4
+  - 2.2.3
   - 2.2.2
+  - 2.1.8
 before_install: gem install bundler -v 1.10.4


### PR DESCRIPTION
## Support ruby 2.1+

Required keyword arguments weren't introduced until ruby-2.1. The
forking_resolution_strategy.rb makes use of required keyword arguments
to ensure that the caller passes a 'promise' for resolution.

Maybe revisit this design choice later, but for now expand CI coverage to 
the most recent releases of MRI Ruby.
