### PR TITLE
Feature/favor stabby lambdas

### DIFF
--- a/spec/futurist/forking_resolution_strategy_spec.rb
+++ b/spec/futurist/forking_resolution_strategy_spec.rb
@@ -82,7 +82,7 @@ describe Futurist::ForkingResolutionStrategy do
 
   it "reraises errors which occur in the forked process" do
     error = StandardError.new("expected")
-    callable = Proc.new { fail error }
+    callable = ->() { fail error }
     promise = Futurist::Promise.new(callable: callable)
     strategy = Futurist::ForkingResolutionStrategy.new(promise: promise)
 
@@ -102,14 +102,10 @@ describe Futurist::ForkingResolutionStrategy do
   end
 
   it "is ready after the process has exited" do
-    def ready_monitor_initializer(_process_id)
-      stub_monitor(ready: true)
-    end
-    ready_monitor_constructor = method(:ready_monitor_initializer)
     allow_any_instance_of(Futurist::ForkingResolutionStrategy).
       to receive(:start_promise_evaluation)
     strategy = Futurist::ForkingResolutionStrategy.new(
-      process_monitor_constructor: ready_monitor_constructor,
+      process_monitor_constructor: ->(_) { stub_monitor(ready: true) },
       promise: stub_promise
     )
     allow(strategy).
@@ -122,14 +118,10 @@ describe Futurist::ForkingResolutionStrategy do
   end
 
   it "is not ready when the process has not yet exited" do
-    def not_ready_monitor_initializer(_process_id)
-      stub_monitor(ready: false)
-    end
-    not_ready_monitor_constructor = method(:not_ready_monitor_initializer)
     allow_any_instance_of(Futurist::ForkingResolutionStrategy).
       to receive(:start_promise_evaluation)
     strategy = Futurist::ForkingResolutionStrategy.new(
-      process_monitor_constructor: not_ready_monitor_constructor,
+      process_monitor_constructor: ->(_) { stub_monitor(ready: false) },
       promise: stub_promise
     )
     allow(strategy).

--- a/spec/futurist/promise_spec.rb
+++ b/spec/futurist/promise_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Futurist::Promise do
   it "is a proxy to the value of its callable" do
     value = double(:value)
-    callable = Proc.new { value }
+    callable = ->() { value }
     promise = Futurist::Promise.new(callable: callable)
 
     expect(promise.value).

--- a/spec/futurist/safe_promise_spec.rb
+++ b/spec/futurist/safe_promise_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Futurist::SafePromise do
   it "returns the value of the promise" do
     value = double(:value)
-    callable = Proc.new { value }
+    callable = -> () { value }
     promise = Futurist::Promise.new(callable: callable)
     safe_promise = Futurist::SafePromise.new(promise)
 
@@ -12,7 +12,7 @@ describe Futurist::SafePromise do
   end
 
   it "returns the exception as its value when the promise raises an error" do
-    callable = Proc.new { fail StandardError, "expected" }
+    callable = ->() { fail StandardError, "expected" }
     promise = Futurist::Promise.new(callable: callable)
     safe_promise = Futurist::SafePromise.new(promise)
 


### PR DESCRIPTION
Construction of callables in specs varies from example to
example. Some use Proc.new, some create new methods and pass them by
name, others use the stabby, ->(){}, lambda syntax. Change all of the
examples to use the stabby lambda syntax for callables so, at least,
the examples are consistent.
