### PR TITLE
Update rubocop to version 0.51.0

### DIFF
--- a/futurist.gemspec
+++ b/futurist.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "rubocop", "~> 0.33"
+  spec.add_development_dependency "rubocop", "~> 0.51.0"
 end


### PR DESCRIPTION
Summary
-------

Apparently there's a low severity security vulnerability in version
range < 0.48.1 - or so sayeth the Github. At any rate, this is part of
a larger effort to update the development dependencies of Futurist.