### PR TITLE
Upgrade rspec to version 3.5.x

### DIFF
--- a/futurist.gemspec
+++ b/futurist.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.4.0"
+  spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "rubocop", "~> 0.51.0"
 end


### PR DESCRIPTION
Summary
-------

This is an incremental step in the upgrade of the rspec development
dependency. It is part of a larger effort to bring Futurist's
development dependencies up to date.