### PR TITLE
Upgrade rspec to version 3.7.x

### DIFF
--- a/futurist.gemspec
+++ b/futurist.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.6.0"
+  spec.add_development_dependency "rspec", "~> 3.7.0"
   spec.add_development_dependency "rubocop", "~> 0.51.0"
 end


### PR DESCRIPTION
Summary
-------

This is the final stop along the upgrade path for rspec for now.