### PR TITLE
Upgrade rake to version 11.x

### DIFF
--- a/futurist.gemspec
+++ b/futurist.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"
   spec.add_development_dependency "pry", "~> 0.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rspec", "~> 3.7.0"
   spec.add_development_dependency "rubocop", "~> 0.51.0"
 end


### PR DESCRIPTION
Summary
-------

Let's try and use a more current version of rake. This is part of the
larger effort to update the development dependencies of Futurist.