### PR TITLE
Upgrade codeclimate-test-reporter to version 1.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ rvm:
   - 2.2.2
   - 2.1.8
 before_install: gem install bundler
+after_success: bundle exec codeclimate-test-reporter

--- a/futurist.gemspec
+++ b/futurist.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"
+  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.7.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require "simplecov"
+SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "futurist"


### PR DESCRIPTION
Summary
-------

This is part of a larger effort to update Futurist's development
dependencies.

References
----------

- https://github.com/codeclimate/ruby-test-reporter/blob/master/CHANGELOG.md#v100-2016-11-03